### PR TITLE
build using the old ABI for glib to match dfhack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ INC = -I"$(DH)/library/include" -I"$(DH)/library/proto" -I"$(DH)/depends/protobu
 LIB = -L"$(DH)/build/library" -ldfhack -ldfhack-version
 
 CXX ?= c++
-CFLAGS = $(INC) -m64 -DLINUX_BUILD -O3
+CFLAGS = $(INC) -m64 -DLINUX_BUILD -O3 -D_GLIBCXX_USE_CXX11_ABI=0
 LDFLAGS = $(LIB) -shared 
 
 ifeq ($(shell uname -s), Darwin)


### PR DESCRIPTION
I found that I got an error loading the TWBT plugin, and after debugging figured out that it's because of a difference in the ABI used when compiling DFHack and TWBT. It should cause no harm to unconditionally define this macro, as older tools will ignore it.

Documentation is at https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html